### PR TITLE
Fix cargo clippy

### DIFF
--- a/main/src/lib.rs
+++ b/main/src/lib.rs
@@ -108,7 +108,7 @@ impl Options {
     fn prefix_map<'name>(&self, name: &'name str) -> (&str, &'name str) {
         for (old, new) in &self.prefix_map {
             if name.starts_with(&*old) {
-                return (&new, &name[old.len()..]);
+                return (new, &name[old.len()..]);
             }
         }
         ("", name)

--- a/main/src/print/file.rs
+++ b/main/src/print/file.rs
@@ -44,8 +44,8 @@ fn assign_ids_in_unit(unit_index: usize, unit: &Unit, _options: &Options, ids: &
 }
 
 fn assign_merged_ids(file_a: &File, file_b: &File, options: &Options) -> Vec<(Id, Id)> {
-    let ref hash_a = FileHash::new(file_a);
-    let ref hash_b = FileHash::new(file_b);
+    let hash_a = &FileHash::new(file_a);
+    let hash_b = &FileHash::new(file_b);
 
     let mut ids = Vec::new();
     let mut units_a = filter::enumerate_and_filter_units(file_a, options);
@@ -139,6 +139,7 @@ fn assign_unmerged_ids_in_unit(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn assign_merged_ids_in_unit(
     hash_a: &FileHash,
     unit_a_index: usize,
@@ -323,7 +324,7 @@ pub struct PrintIndex {
 }
 
 pub fn print_index(file: &File, options: &Options) -> PrintIndex {
-    let ids = assign_ids(file, &options);
+    let ids = assign_ids(file, options);
     PrintIndex { ids }
 }
 
@@ -447,7 +448,7 @@ pub struct DiffIndex {
 }
 
 pub fn diff_index(file_a: &File, file_b: &File, options: &Options) -> DiffIndex {
-    let ids = assign_merged_ids(file_a, file_b, &options);
+    let ids = assign_merged_ids(file_a, file_b, options);
     DiffIndex { ids }
 }
 
@@ -784,7 +785,7 @@ pub fn bloat_index(file: &File, options: &Options) -> BloatIndex {
                 let id = FunctionId { name, source };
                 let mut function_total = function_totals
                     .entry(id)
-                    .or_insert(FunctionTotal::default());
+                    .or_insert_with(FunctionTotal::default);
                 function_total.size += size;
                 function_total.functions.push((unit_index, function_index));
 

--- a/main/src/print/frame_location.rs
+++ b/main/src/print/frame_location.rs
@@ -79,7 +79,7 @@ impl DiffList for FrameLocation {
 
     fn diff_cost(_state: &DiffState, _unit_a: &(), a: &Self, _unit_b: &(), b: &Self) -> usize {
         let mut cost = 0;
-        if a.cmp(&b) != cmp::Ordering::Equal {
+        if a.cmp(b) != cmp::Ordering::Equal {
             cost += 1;
         }
         cost

--- a/main/src/print/html.rs
+++ b/main/src/print/html.rs
@@ -1,4 +1,3 @@
-use std;
 use std::io::Write;
 
 use marksman_escape::Escape;
@@ -578,7 +577,7 @@ impl<'w> ValuePrinter for HtmlValuePrinter<'w> {
             write!(
                 self.w,
                 "<span title=\"{}\">{}</span>",
-                &escaped_str(&name),
+                &escaped_str(name),
                 &escaped_str(&result)
             )?;
         } else {

--- a/main/src/print/member.rs
+++ b/main/src/print/member.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
 use std::cmp;
-use std::ops::Deref;
 
 use parser::{FileHash, Inherit, Layout, LayoutItem, Member, Type, Unit, Variant, VariantPart};
 
@@ -84,7 +82,7 @@ impl<'input> Print for Member<'input> {
         } else {
             None
         };
-        let ty = ty.as_ref().map(Cow::deref);
+        let ty = ty.as_deref();
         state.expanded(
             |state| state.line(|w, hash| print_member(self, w, hash)),
             |state| print::types::print_members(state, unit, ty),
@@ -97,13 +95,13 @@ impl<'input> Print for Member<'input> {
         } else {
             None
         };
-        let ty_a = ty_a.as_ref().map(Cow::deref);
+        let ty_a = ty_a.as_deref();
         let ty_b = if b.is_inline(state.hash_b()) {
             b.ty(state.hash_b())
         } else {
             None
         };
-        let ty_b = ty_b.as_ref().map(Cow::deref);
+        let ty_b = ty_b.as_deref();
         state.expanded(
             |state| state.line(a, b, |w, hash, x| print_member(x, w, hash)),
             |state| print::types::diff_members(state, unit_a, ty_a, unit_b, ty_b),
@@ -222,7 +220,7 @@ impl<'input, 'member> Print for Layout<'input, 'member> {
             (&LayoutItem::Padding, &LayoutItem::Padding) => {
                 state.line(a, b, |w, _hash, x| print_padding(x, w))
             }
-            (&LayoutItem::Member(ref member_a), &LayoutItem::Member(ref member_b)) => {
+            (&LayoutItem::Member(member_a), &LayoutItem::Member(member_b)) => {
                 Member::diff(state, unit_a, member_a, unit_b, member_b)
             }
             (
@@ -267,15 +265,15 @@ impl<'input, 'member> DiffList for Layout<'input, 'member> {
     fn diff_cost(state: &DiffState, unit_a: &Unit, a: &Self, unit_b: &Unit, b: &Self) -> usize {
         match (&a.item, &b.item) {
             (&LayoutItem::Padding, &LayoutItem::Padding) => 0,
-            (&LayoutItem::Member(ref a), &LayoutItem::Member(ref b)) => {
+            (&LayoutItem::Member(a), &LayoutItem::Member(b)) => {
                 Member::diff_cost(state, unit_a, a, unit_b, b)
             }
-            (&LayoutItem::VariantPart(ref _a), &LayoutItem::VariantPart(ref _b)) => {
+            (&LayoutItem::VariantPart(_a), &LayoutItem::VariantPart(_b)) => {
                 // TODO: for now we assume there is only one variant part
                 // Later we should compare `VariantPart::discr`
                 0
             }
-            (&LayoutItem::Inherit(ref a), &LayoutItem::Inherit(ref b)) => {
+            (&LayoutItem::Inherit(a), &LayoutItem::Inherit(b)) => {
                 Inherit::diff_cost(state, &(), a, &(), b)
             }
             _ => 2,

--- a/main/src/print/text.rs
+++ b/main/src/print/text.rs
@@ -1,4 +1,3 @@
-use std;
 use std::io::Write;
 
 use super::{DiffPrefix, Printer, ValuePrinter};

--- a/main/src/print/type_def.rs
+++ b/main/src/print/type_def.rs
@@ -1,6 +1,3 @@
-use std::borrow::Cow;
-use std::ops::Deref;
-
 use parser::{FileHash, TypeDef, Unit};
 
 use crate::print::{self, DiffState, PrintHeader, PrintState, ValuePrinter};
@@ -79,9 +76,9 @@ impl<'input> PrintHeader for TypeDef<'input> {
         }
         state.field("size", a, b, |w, state, x| print_byte_size(x, w, state))?;
         let ty_a = filter_option(a.ty(state.hash_a()), |ty| ty.is_anon());
-        let ty_a = ty_a.as_ref().map(Cow::deref);
+        let ty_a = ty_a.as_deref();
         let ty_b = filter_option(b.ty(state.hash_b()), |ty| ty.is_anon());
-        let ty_b = ty_b.as_ref().map(Cow::deref);
+        let ty_b = ty_b.as_deref();
         state.field_expanded("members", |state| {
             print::types::diff_members(state, unit_a, ty_a, unit_b, ty_b)
         })

--- a/main/tests/diff.rs
+++ b/main/tests/diff.rs
@@ -16,7 +16,7 @@ fn diff(name: &str, expect: &str) {
     }
 }
 
-fn options<'a>() -> ddbug::Options {
+fn options() -> ddbug::Options {
     ddbug::Options {
         print_function_variables: true,
         inline_depth: 1,

--- a/parser/src/file/dwarf.rs
+++ b/parser/src/file/dwarf.rs
@@ -4,7 +4,6 @@ use std::mem;
 use std::sync::Arc;
 use std::u32;
 
-use gimli;
 use gimli::Reader as GimliReader;
 use object::{self, ObjectSection, ObjectSymbol};
 
@@ -402,7 +401,7 @@ where
             }
             None => &[],
         };
-        let relocations = arena.add_relocations(Box::new(relocations));
+        let relocations = arena.add_relocations(relocations);
         let reader = gimli::EndianSlice::new(data, endian);
         Ok(Relocate {
             relocations,
@@ -450,8 +449,10 @@ fn parse_unit<'input, Endian>(
 where
     Endian: gimli::Endianity,
 {
-    let mut unit = Unit::default();
-    unit.address_size = Some(u64::from(dwarf_unit.header.address_size()));
+    let mut unit = Unit {
+        address_size: Some(u64::from(dwarf_unit.header.address_size())),
+        ..Default::default()
+    };
 
     let mut subprograms = Vec::new();
     let mut variables = Vec::new();
@@ -1054,11 +1055,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown type modifier child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown type modifier child tag: {}", tag);
     }
     Ok(modifier)
 }
@@ -1125,11 +1123,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown base type child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown base type child tag: {}", tag);
     }
     Ok(ty)
 }
@@ -1143,8 +1138,10 @@ fn parse_typedef<'input, 'abbrev, 'unit, 'tree, Endian>(
 where
     Endian: gimli::Endianity,
 {
-    let mut typedef = TypeDef::default();
-    typedef.namespace = namespace.clone();
+    let mut typedef = TypeDef {
+        namespace: namespace.clone(),
+        ..Default::default()
+    };
 
     let mut attrs = node.entry().attrs();
     while let Some(attr) = attrs.next()? {
@@ -1173,11 +1170,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown typedef child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown typedef child tag: {}", tag);
     }
     Ok(typedef)
 }
@@ -1194,8 +1188,10 @@ fn parse_structure_type<'input, 'abbrev, 'unit, 'tree, Endian>(
 where
     Endian: gimli::Endianity,
 {
-    let mut ty = StructType::default();
-    ty.namespace = namespace.clone();
+    let mut ty = StructType {
+        namespace: namespace.clone(),
+        ..Default::default()
+    };
 
     let mut attrs = node.entry().attrs();
     while let Some(attr) = attrs.next()? {
@@ -1290,8 +1286,10 @@ fn parse_union_type<'input, 'abbrev, 'unit, 'tree, Endian>(
 where
     Endian: gimli::Endianity,
 {
-    let mut ty = UnionType::default();
-    ty.namespace = namespace.clone();
+    let mut ty = UnionType {
+        namespace: namespace.clone(),
+        ..Default::default()
+    };
 
     let mut attrs = node.entry().attrs();
     while let Some(attr) = attrs.next()? {
@@ -1635,11 +1633,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown member child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown member child tag: {}", tag);
     }
     members.push(member);
     Ok(())
@@ -1681,11 +1676,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown inheritance child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown inheritance child tag: {}", tag);
     }
     inherits.push(inherit);
     Ok(())
@@ -1858,11 +1850,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown enumerator child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown enumerator child tag: {}", tag);
     }
     Ok(enumerator)
 }
@@ -2000,11 +1989,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown subrange child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown subrange child tag: {}", tag);
     }
     Ok(subrange)
 }
@@ -2064,8 +2050,10 @@ fn parse_unspecified_type<'input, 'abbrev, 'unit, 'tree, Endian>(
 where
     Endian: gimli::Endianity,
 {
-    let mut ty = UnspecifiedType::default();
-    ty.namespace = namespace.clone();
+    let mut ty = UnspecifiedType {
+        namespace: namespace.clone(),
+        ..Default::default()
+    };
 
     let mut attrs = node.entry().attrs();
     while let Some(attr) = attrs.next()? {
@@ -2083,11 +2071,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown unspecified type child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown unspecified type child tag: {}", tag);
     }
     Ok(ty)
 }
@@ -2133,11 +2118,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown ptr_to_member type child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown ptr_to_member type child tag: {}", tag);
     }
     Ok(ty)
 }
@@ -2270,8 +2252,8 @@ where
     }
 
     if let Some(offset) = ranges {
-        let offset = dwarf.read.ranges_offset_from_raw(&dwarf_unit, offset);
-        let mut ranges = dwarf.read.ranges(&dwarf_unit, offset)?;
+        let offset = dwarf.read.ranges_offset_from_raw(dwarf_unit, offset);
+        let mut ranges = dwarf.read.ranges(dwarf_unit, offset)?;
         let mut size = 0;
         while let Some(range) = ranges.next()? {
             if range.end > range.begin {
@@ -2485,11 +2467,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown parameter child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown parameter child tag: {}", tag);
     }
 
     if let Some(abstract_origin) = abstract_origin {
@@ -2601,11 +2580,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown parameter child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown parameter child tag: {}", tag);
     }
 
     if let Some(abstract_origin) = abstract_origin {
@@ -2729,8 +2705,8 @@ where
 }
 
 // Only checks for unknown attributes and tags.
-fn parse_inlined_subroutine<'input, 'abbrev, 'unit, 'tree, Endian>(
-    node: gimli::EntriesTreeNode<'abbrev, 'unit, 'tree, Reader<'input, Endian>>,
+fn parse_inlined_subroutine<Endian>(
+    node: gimli::EntriesTreeNode<'_, '_, '_, Reader<'_, Endian>>,
 ) -> Result<()>
 where
     Endian: gimli::Endianity,
@@ -2757,8 +2733,8 @@ where
 }
 
 // Only checks for unknown attributes and tags.
-fn parse_inlined_lexical_block<'input, 'abbrev, 'unit, 'tree, Endian>(
-    node: gimli::EntriesTreeNode<'abbrev, 'unit, 'tree, Reader<'input, Endian>>,
+fn parse_inlined_lexical_block<Endian>(
+    node: gimli::EntriesTreeNode<'_, '_, '_, Reader<'_, Endian>>,
 ) -> Result<()>
 where
     Endian: gimli::Endianity,
@@ -3119,11 +3095,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown variable child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown variable child tag: {}", tag);
     }
 
     Ok(DwarfVariable {
@@ -3211,11 +3184,8 @@ where
 
     let mut iter = node.children();
     while let Some(child) = iter.next()? {
-        match child.entry().tag() {
-            tag => {
-                debug!("unknown variable child tag: {}", tag);
-            }
-        }
+        let tag = child.entry().tag();
+        debug!("unknown variable child tag: {}", tag);
     }
 
     if let Some(abstract_origin) = abstract_origin {
@@ -4087,8 +4057,8 @@ where
         );
     }
 
-    let mut cfi = Vec::new();
-    cfi.push((Address::none(), CfiDirective::StartProc));
+    let mut cfi = vec![(Address::none(), CfiDirective::StartProc)];
+
     if let Some(personality) = fde.personality() {
         // TODO: better handling of indirect
         let address = match personality {

--- a/parser/src/file/mod.rs
+++ b/parser/src/file/mod.rs
@@ -2,14 +2,11 @@ use std::borrow::Cow;
 use std::default::Default;
 use std::fs;
 use std::mem;
-use std::ops::Deref;
 use std::sync::Mutex;
 
 mod dwarf;
 
 use fnv::FnvHashMap as HashMap;
-use gimli;
-use memmap;
 use object::{self, Object, ObjectSection, ObjectSegment, ObjectSymbol, ObjectSymbolTable};
 
 use crate::cfi::Cfi;
@@ -71,7 +68,7 @@ pub(crate) struct Arena {
     // TODO: can these be a single `Vec<Box<dyn ??>>`?
     buffers: Mutex<Vec<Vec<u8>>>,
     strings: Mutex<Vec<String>>,
-    relocations: Mutex<Vec<Box<dwarf::RelocationMap>>>,
+    relocations: Mutex<Vec<dwarf::RelocationMap>>,
 }
 
 impl Arena {
@@ -108,7 +105,7 @@ impl Arena {
 
     fn add_relocations<'input>(
         &'input self,
-        entry: Box<dwarf::RelocationMap>,
+        entry: dwarf::RelocationMap,
     ) -> &'input dwarf::RelocationMap {
         let mut relocations = self.relocations.lock().unwrap();
         let i = relocations.len();
@@ -361,8 +358,11 @@ impl<'input> File<'input> {
         }
 
         // Create a unit for symbols that don't have debuginfo.
-        let mut unit = Unit::default();
-        unit.name = Some(Cow::Borrowed("<symtab>"));
+        let mut unit = Unit {
+            name: Some(Cow::Borrowed("<symtab>")),
+            ..Default::default()
+        };
+
         for (symbol, used) in self.symbols.iter().zip(used_symbols.iter()) {
             if *used {
                 continue;
@@ -404,8 +404,11 @@ impl<'input> File<'input> {
         self.units.push(unit);
 
         // Create a unit for all remaining address ranges.
-        let mut unit = Unit::default();
-        unit.name = Some(Cow::Borrowed("<unknown>"));
+        let mut unit = Unit {
+            name: Some(Cow::Borrowed("<unknown>")),
+            ..Default::default()
+        };
+
         unit.ranges = self.unknown_ranges();
         self.units.push(unit);
     }
@@ -663,12 +666,12 @@ pub struct Section<'input> {
 impl<'input> Section<'input> {
     /// The name of this section.
     pub fn name(&self) -> Option<&str> {
-        self.name.as_ref().map(Cow::deref)
+        self.name.as_deref()
     }
 
     /// The name of the segment containing this section, if applicable.
     pub fn segment(&self) -> Option<&str> {
-        self.segment.as_ref().map(Cow::deref)
+        self.segment.as_deref()
     }
 
     /// The address range covered by this section if it is loadable.

--- a/parser/src/file/mod.rs
+++ b/parser/src/file/mod.rs
@@ -68,7 +68,9 @@ pub(crate) struct Arena {
     // TODO: can these be a single `Vec<Box<dyn ??>>`?
     buffers: Mutex<Vec<Vec<u8>>>,
     strings: Mutex<Vec<String>>,
-    relocations: Mutex<Vec<dwarf::RelocationMap>>,
+    // It's crusial to have a box because we then transume it.
+    #[allow(clippy::vec_box)]
+    relocations: Mutex<Vec<Box<dwarf::RelocationMap>>>,
 }
 
 impl Arena {
@@ -109,7 +111,7 @@ impl Arena {
     ) -> &'input dwarf::RelocationMap {
         let mut relocations = self.relocations.lock().unwrap();
         let i = relocations.len();
-        relocations.push(entry);
+        relocations.push(Box::new(entry));
         let entry = &relocations[i];
         unsafe { mem::transmute::<&dwarf::RelocationMap, &'input dwarf::RelocationMap>(entry) }
     }

--- a/parser/src/function.rs
+++ b/parser/src/function.rs
@@ -111,7 +111,7 @@ impl<'input> Function<'input> {
 
     /// The namespace of the function.
     pub fn namespace(&self) -> Option<&Namespace> {
-        self.namespace.as_ref().map(|x| &**x)
+        self.namespace.as_deref()
     }
 
     /// The name of the function.
@@ -286,17 +286,17 @@ impl<'input> Parameter<'input> {
     }
 
     /// The registers in which this parameter is stored.
-    pub fn registers<'a>(&'a self) -> impl Iterator<Item = (Range, Register)> + 'a {
+    pub fn registers(&self) -> impl Iterator<Item = (Range, Register)> + '_ {
         location::registers(&self.locations)
     }
 
     /// The registers pointing to where this variable is stored.
-    pub fn register_offsets<'a>(&'a self) -> impl Iterator<Item = (Range, Register, i64)> + 'a {
+    pub fn register_offsets(&self) -> impl Iterator<Item = (Range, Register, i64)> + '_ {
         location::register_offsets(&self.locations)
     }
 
     /// The stack frame locations at which this parameter is stored.
-    pub fn frame_locations<'a>(&'a self) -> impl Iterator<Item = FrameLocation> + 'a {
+    pub fn frame_locations(&self) -> impl Iterator<Item = FrameLocation> + '_ {
         location::frame_locations(&self.locations)
     }
 

--- a/parser/src/location.rs
+++ b/parser/src/location.rs
@@ -84,9 +84,9 @@ pub(crate) enum Location {
     Other,
 }
 
-pub(crate) fn registers<'a>(
-    locations: &'a [(Range, Piece)],
-) -> impl Iterator<Item = (Range, Register)> + 'a {
+pub(crate) fn registers(
+    locations: &[(Range, Piece)],
+) -> impl Iterator<Item = (Range, Register)> + '_ {
     locations.iter().filter_map(|(range, piece)| {
         if piece.is_value {
             return None;
@@ -98,9 +98,9 @@ pub(crate) fn registers<'a>(
     })
 }
 
-pub(crate) fn frame_locations<'a>(
-    locations: &'a [(Range, Piece)],
-) -> impl Iterator<Item = FrameLocation> + 'a {
+pub(crate) fn frame_locations(
+    locations: &[(Range, Piece)],
+) -> impl Iterator<Item = FrameLocation> + '_ {
     locations.iter().filter_map(|(_, piece)| {
         if piece.is_value {
             return None;
@@ -118,9 +118,9 @@ pub(crate) fn frame_locations<'a>(
     })
 }
 
-pub(crate) fn register_offsets<'a>(
-    locations: &'a [(Range, Piece)],
-) -> impl Iterator<Item = (Range, Register, i64)> + 'a {
+pub(crate) fn register_offsets(
+    locations: &[(Range, Piece)],
+) -> impl Iterator<Item = (Range, Register, i64)> + '_ {
     locations.iter().filter_map(|(range, piece)| {
         if piece.is_value {
             return None;

--- a/parser/src/namespace.rs
+++ b/parser/src/namespace.rs
@@ -35,7 +35,7 @@ impl<'input> Namespace<'input> {
 
     /// The parent namespace.
     pub fn parent(&self) -> Option<&Namespace<'input>> {
-        self.parent.as_ref().map(|x| &**x)
+        self.parent.as_deref()
     }
 
     /// The namespace name.
@@ -165,8 +165,8 @@ mod test {
 
     #[test]
     fn cmp() {
-        let ns1 = Namespace::new(&None, Some("a".into()), NamespaceKind::Namespace);
-        let ns2 = Namespace::new(&None, Some("b".into()), NamespaceKind::Namespace);
+        let ns1 = Namespace::new(&None, Some("a"), NamespaceKind::Namespace);
+        let ns2 = Namespace::new(&None, Some("b"), NamespaceKind::Namespace);
         assert_eq!(Namespace::cmp(&ns1, &ns2), cmp::Ordering::Less);
     }
 }

--- a/parser/src/types.rs
+++ b/parser/src/types.rs
@@ -151,10 +151,7 @@ impl<'input> Type<'input> {
     /// Return true if the type is the void type.
     #[inline]
     pub fn is_void(&self) -> bool {
-        match self.kind {
-            TypeKind::Void => true,
-            _ => false,
-        }
+        matches!(self.kind, TypeKind::Void)
     }
 
     /// The user defined id for this type.
@@ -537,7 +534,7 @@ pub struct TypeDef<'input> {
 impl<'input> TypeDef<'input> {
     /// The namespace of the type.
     pub fn namespace(&self) -> Option<&Namespace> {
-        self.namespace.as_ref().map(|x| &**x)
+        self.namespace.as_deref()
     }
 
     /// The name of the type definition.
@@ -591,7 +588,7 @@ pub struct StructType<'input> {
 impl<'input> StructType<'input> {
     /// The namespace of the type.
     pub fn namespace(&self) -> Option<&Namespace> {
-        self.namespace.as_ref().map(|x| &**x)
+        self.namespace.as_deref()
     }
 
     /// The name of the type.
@@ -684,7 +681,7 @@ pub struct UnionType<'input> {
 impl<'input> UnionType<'input> {
     /// The namespace of the type.
     pub fn namespace(&self) -> Option<&Namespace> {
-        self.namespace.as_ref().map(|x| &**x)
+        self.namespace.as_deref()
     }
 
     /// The name of the type.
@@ -1115,7 +1112,7 @@ pub struct EnumerationType<'input> {
 impl<'input> EnumerationType<'input> {
     /// The namespace of the type.
     pub fn namespace(&self) -> Option<&Namespace> {
-        self.namespace.as_ref().map(|x| &**x)
+        self.namespace.as_deref()
     }
 
     /// The name of the type.
@@ -1454,7 +1451,7 @@ pub struct UnspecifiedType<'input> {
 impl<'input> UnspecifiedType<'input> {
     /// The namespace of the type.
     pub fn namespace(&self) -> Option<&Namespace> {
-        self.namespace.as_ref().map(|x| &**x)
+        self.namespace.as_deref()
     }
 
     /// The name of the type.

--- a/parser/src/unit.rs
+++ b/parser/src/unit.rs
@@ -1,7 +1,4 @@
 use std::borrow::Cow;
-use std::ops::Deref;
-
-use gimli;
 
 use crate::file::FileHash;
 use crate::function::Function;
@@ -17,6 +14,7 @@ pub struct Unit<'input> {
     pub(crate) dir: Option<Cow<'input, str>>,
     pub(crate) name: Option<Cow<'input, str>>,
     pub(crate) language: Option<gimli::DwLang>,
+    #[allow(dead_code)]
     pub(crate) address_size: Option<u64>,
     pub(crate) low_pc: Option<u64>,
     pub(crate) ranges: RangeList,
@@ -40,12 +38,12 @@ impl<'input> Unit<'input> {
 
     /// The working directory when the unit was compiled.
     pub fn dir(&self) -> Option<&str> {
-        self.dir.as_ref().map(Cow::deref)
+        self.dir.as_deref()
     }
 
     /// The path of the primary source file.
     pub fn name(&self) -> Option<&str> {
-        self.name.as_ref().map(Cow::deref)
+        self.name.as_deref()
     }
 
     /// The source language.

--- a/parser/src/variable.rs
+++ b/parser/src/variable.rs
@@ -68,7 +68,7 @@ impl<'input> Variable<'input> {
 
     /// The namespace of the variable.
     pub fn namespace(&self) -> Option<&Namespace> {
-        self.namespace.as_ref().map(|x| &**x)
+        self.namespace.as_deref()
     }
 
     /// The name of the variable.
@@ -218,17 +218,17 @@ impl<'input> LocalVariable<'input> {
     }
 
     /// The registers in which this variable is stored.
-    pub fn registers<'a>(&'a self) -> impl Iterator<Item = (Range, Register)> + 'a {
+    pub fn registers(&self) -> impl Iterator<Item = (Range, Register)> + '_ {
         location::registers(&self.locations)
     }
 
     /// The registers pointing to where this variable is stored.
-    pub fn register_offsets<'a>(&'a self) -> impl Iterator<Item = (Range, Register, i64)> + 'a {
+    pub fn register_offsets(&self) -> impl Iterator<Item = (Range, Register, i64)> + '_ {
         location::register_offsets(&self.locations)
     }
 
     /// The stack frame locations at which this variable is stored.
-    pub fn frame_locations<'a>(&'a self) -> impl Iterator<Item = FrameLocation> + 'a {
+    pub fn frame_locations(&self) -> impl Iterator<Item = FrameLocation> + '_ {
         self.locations.iter().filter_map(|(_, piece)| {
             if piece.is_value {
                 return None;


### PR DESCRIPTION
Hi there

I was kind of studying the source code and decided to delivery a clippy fixes along the way.

A note:

Unit address_size is unused so could be deleted.
Maybe there's some plan for it so I've left it.

PS: if you don't mind could you elaborate on this comment?

```
// TODO: handle `lea rax, [rip + offset]; call rax`
```

As I understand the offset will be no calculated correctly in case of lea usage?