### PR TITLE
Support for Wasm object

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -13,7 +13,7 @@ fnv = "1.0"
 gimli = "0.27.0"
 log = "0.4"
 memmap = "0.7"
-object = "0.30.0"
+object = { version = "0.30.0", features = ["wasm"] }
 
 [features]
 default = []


### PR DESCRIPTION
Enable the `object` Wasm support allows ddbug to support Wasm DWARF.

Example:
```
ddbug /path/to/module.wasm
```