### PR TITLE
Expose mmap file parse

### DIFF
--- a/parser/src/file/mod.rs
+++ b/parser/src/file/mod.rs
@@ -201,6 +201,11 @@ impl<'input> File<'input> {
             }
         };
 
+        Self::parse_map(map, path)
+    }
+
+    /// Parse the file from memory map.
+    pub fn parse_map(map: memmap2::Mmap, path: String) -> Result<FileContext> {
         // TODO: split DWARF
         // TODO: PDB
         FileContext::new(map, |data, strings| {


### PR DESCRIPTION
Currently it's not possible to parse an object file from an in-memory buffer. By exposing a parse function that accepts the `Mmap` directly we can at least remove the need to write the object to a file first.

Example usage:
```rust
let mut map = memmap2::MmapMut::map_anon(bytes.len()).expect("failed to create mmap");

// write file into map
for (i, byte) in bytes.iter().copied().enumerate() {
    map[i] = byte;
}

let map = map.make_read_only().expect("failed to make mmap read-only");

ddbug_parser::File::parse_map(map, "/path/object.elf");
```

Further steps to consider:
- make `path` optional (would break existing code)
- make parse generic over any object reader