### PR TITLE
Precise return type lifetime for accessor methods

### DIFF
--- a/parser/src/function.rs
+++ b/parser/src/function.rs
@@ -109,19 +109,19 @@ impl<'input> Function<'input> {
     }
 
     /// The namespace of the function.
-    pub fn namespace(&self) -> Option<&Namespace> {
+    pub fn namespace(&self) -> Option<&Namespace<'input>> {
         self.namespace.as_deref()
     }
 
     /// The name of the function.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
     /// The linkage name of the variable.
     #[inline]
-    pub fn linkage_name(&self) -> Option<&str> {
+    pub fn linkage_name(&self) -> Option<&'input str> {
         self.linkage_name
     }
 
@@ -129,7 +129,7 @@ impl<'input> Function<'input> {
     ///
     /// This is determined from a symbol table entry with a matching address.
     #[inline]
-    pub fn symbol_name(&self) -> Option<&str> {
+    pub fn symbol_name(&self) -> Option<&'input str> {
         self.symbol_name
     }
 

--- a/parser/src/namespace.rs
+++ b/parser/src/namespace.rs
@@ -40,7 +40,7 @@ impl<'input> Namespace<'input> {
 
     /// The namespace name.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -57,7 +57,7 @@ impl<'input> Namespace<'input> {
         }
     }
 
-    fn up(&self, len: usize) -> &Namespace {
+    fn up(&self, len: usize) -> &Namespace<'input> {
         if len == 0 {
             self
         } else {

--- a/parser/src/source.rs
+++ b/parser/src/source.rs
@@ -14,13 +14,13 @@ impl<'input> Source<'input> {
     ///
     /// This may be absolute, or relative to the working directory of the unit.
     #[inline]
-    pub fn directory(&self) -> Option<&str> {
+    pub fn directory(&self) -> Option<&'input str> {
         self.directory
     }
 
     /// The file name.
     #[inline]
-    pub fn file(&self) -> Option<&str> {
+    pub fn file(&self) -> Option<&'input str> {
         self.file
     }
 

--- a/parser/src/types.rs
+++ b/parser/src/types.rs
@@ -355,7 +355,7 @@ impl<'input> TypeModifier<'input> {
     ///
     /// If this is `None` then the name should be derived from the type that is being modified.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -488,7 +488,7 @@ pub struct BaseType<'input> {
 impl<'input> BaseType<'input> {
     /// The name of the type.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -532,13 +532,13 @@ pub struct TypeDef<'input> {
 
 impl<'input> TypeDef<'input> {
     /// The namespace of the type.
-    pub fn namespace(&self) -> Option<&Namespace> {
+    pub fn namespace(&self) -> Option<&Namespace<'input>> {
         self.namespace.as_deref()
     }
 
     /// The name of the type definition.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -586,13 +586,13 @@ pub struct StructType<'input> {
 
 impl<'input> StructType<'input> {
     /// The namespace of the type.
-    pub fn namespace(&self) -> Option<&Namespace> {
+    pub fn namespace(&self) -> Option<&Namespace<'input>> {
         self.namespace.as_deref()
     }
 
     /// The name of the type.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -679,13 +679,13 @@ pub struct UnionType<'input> {
 
 impl<'input> UnionType<'input> {
     /// The namespace of the type.
-    pub fn namespace(&self) -> Option<&Namespace> {
+    pub fn namespace(&self) -> Option<&Namespace<'input>> {
         self.namespace.as_deref()
     }
 
     /// The name of the type.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -813,7 +813,7 @@ impl<'input> Variant<'input> {
     ///
     /// Currently this is only set for Rust enums.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -922,7 +922,7 @@ pub struct Member<'input> {
 impl<'input> Member<'input> {
     /// The name of the member.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -1111,13 +1111,13 @@ pub struct EnumerationType<'input> {
 
 impl<'input> EnumerationType<'input> {
     /// The namespace of the type.
-    pub fn namespace(&self) -> Option<&Namespace> {
+    pub fn namespace(&self) -> Option<&Namespace<'input>> {
         self.namespace.as_deref()
     }
 
     /// The name of the type.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -1174,7 +1174,7 @@ pub struct Enumerator<'input> {
 impl<'input> Enumerator<'input> {
     /// The name of the enumerator.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -1471,13 +1471,13 @@ pub struct UnspecifiedType<'input> {
 
 impl<'input> UnspecifiedType<'input> {
     /// The namespace of the type.
-    pub fn namespace(&self) -> Option<&Namespace> {
+    pub fn namespace(&self) -> Option<&Namespace<'input>> {
         self.namespace.as_deref()
     }
 
     /// The name of the type.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 

--- a/parser/src/variable.rs
+++ b/parser/src/variable.rs
@@ -66,19 +66,19 @@ impl<'input> Variable<'input> {
     }
 
     /// The namespace of the variable.
-    pub fn namespace(&self) -> Option<&Namespace> {
+    pub fn namespace(&self) -> Option<&Namespace<'input>> {
         self.namespace.as_deref()
     }
 
     /// The name of the variable.
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
     /// The linkage name of the variable.
     #[inline]
-    pub fn linkage_name(&self) -> Option<&str> {
+    pub fn linkage_name(&self) -> Option<&'input str> {
         self.linkage_name
     }
 
@@ -86,7 +86,7 @@ impl<'input> Variable<'input> {
     ///
     /// This is determined from a symbol table entry with a matching address.
     #[inline]
-    pub fn symbol_name(&self) -> Option<&str> {
+    pub fn symbol_name(&self) -> Option<&'input str> {
         self.symbol_name
     }
 


### PR DESCRIPTION
This change prevents losing some lifetime information. 
This is needed by calling code to avoid adding needless clone calls :)

BTW thanks for this awesome crate :D